### PR TITLE
Improve example listing and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ To get started with the ESP32-C3 Super Mini, you’ll need:
 
 #### **5. Upload a Test Sketch**
 1. Open a new sketch in the Arduino IDE.
-2. Add a simple example like the Blink sketch ([Blink Project](/docs/examples/Blink/README.md)).
+2. Add a simple example like the Blink sketch ([Blink Project](docs/examples/Blink/README.md)).
 3. Click **Upload** to send the sketch to your ESP32-C3.
 
 If everything is set up correctly, the LED on the ESP32-C3 should start blinking, indicating that the upload was successful.
@@ -156,26 +156,26 @@ The ESP32-C3 Super Mini supports a wide range of peripherals:
  ### **1. Blink LED**: 
 
   **A basic example to blink an LED.**
-  - Guide: [Blink Project](/docs/examples/Blink/README.md)
-  - Code: [blink.ino](/docs/examples/Blink/Blink.ino)
+  - Guide: [Blink Project](docs/examples/Blink/README.md)
+  - Code: [blink.ino](docs/examples/Blink/Blink.ino)
 
 ### **2. ESP32 C3 Super Mini with DHT11/DHT22**: 
 
   **Read temperature and humidity using DHT11/DHT22.**
-  - Guide: [ESP32 C3 Super Mini with DHT11](/docs/examples/ESP32_C3_Super_Mini_with_DHT11/README.md)
-  - Code: [ESP32_C3_Super_Mini_with_DHT11.ino](/docs/examples/ESP32_C3_Super_Mini_with_DHT11/ESP32_C3_Super_Mini_with_DHT11.ino)
+  - Guide: [ESP32 C3 Super Mini with DHT11](docs/examples/ESP32_C3_Super_Mini_with_DHT11/README.md)
+  - Code: [ESP32_C3_Super_Mini_with_DHT11.ino](docs/examples/ESP32_C3_Super_Mini_with_DHT11/ESP32_C3_Super_Mini_with_DHT11.ino)
 
 ### **3. ESP32-C3 Super Mini with DHT11/DHT22 - Display values using web server**:
 
   **To read temperature and humidity data from a DHT11/DHT22 sensor and display these values on a web server.**
-  - Guide: [Read DHT11/DHT22 - Display Values Using Web Server](/docs/examples/ESP32_C3_Super_Mini_with_DHT11_webServer/README.md)
-  - Code: [ESP32_C3_Super_Mini_with_DHT11_webServer.ino](/docs/examples/ESP32_C3_Super_Mini_with_DHT11_webServer/ESP32_C3_Super_Mini_with_DHT11_webServer.ino)
+  - Guide: [Read DHT11/DHT22 - Display Values Using Web Server](docs/examples/ESP32_C3_Super_Mini_with_DHT11_webServer/README.md)
+  - Code: [ESP32_C3_Super_Mini_with_DHT11_webServer.ino](docs/examples/ESP32_C3_Super_Mini_with_DHT11_webServer/ESP32_C3_Super_Mini_with_DHT11_webServer.ino)
 
 ### **4. WiFi Scanner mit OLED**:
 
   **Scanne nach WLAN-Netzen und zeige bis zu fünf Netzwerknamen mit ihrer Signalstärke in Prozent an.**
-  - Guide: [WiFi Scanner mit OLED](/docs/examples/ESP32_C3_Super_Mini_WiFi_Scan_OLED/README.md)
-  - Code: [ESP32_C3_Super_Mini_WiFi_Scan_OLED.ino](/docs/examples/ESP32_C3_Super_Mini_WiFi_Scan_OLED/ESP32_C3_Super_Mini_WiFi_Scan_OLED.ino)
+  - Guide: [WiFi Scanner mit OLED](docs/examples/ESP32_C3_Super_Mini_WiFi_Scan_OLED/README.md)
+  - Code: [ESP32_C3_Super_Mini_WiFi_Scan_OLED.ino](docs/examples/ESP32_C3_Super_Mini_WiFi_Scan_OLED/ESP32_C3_Super_Mini_WiFi_Scan_OLED.ino)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -165,11 +165,17 @@ The ESP32-C3 Super Mini supports a wide range of peripherals:
   - Guide: [ESP32 C3 Super Mini with DHT11](/docs/examples/ESP32_C3_Super_Mini_with_DHT11/README.md)
   - Code: [ESP32_C3_Super_Mini_with_DHT11.ino](/docs/examples/ESP32_C3_Super_Mini_with_DHT11/ESP32_C3_Super_Mini_with_DHT11.ino)
 
-### **3. ESP32-C3 Super Mini with DHT11/DHT22 - Display values using web server**: 
+### **3. ESP32-C3 Super Mini with DHT11/DHT22 - Display values using web server**:
 
   **To read temperature and humidity data from a DHT11/DHT22 sensor and display these values on a web server.**
   - Guide: [Read DHT11/DHT22 - Display Values Using Web Server](/docs/examples/ESP32_C3_Super_Mini_with_DHT11_webServer/README.md)
   - Code: [ESP32_C3_Super_Mini_with_DHT11_webServer.ino](/docs/examples/ESP32_C3_Super_Mini_with_DHT11_webServer/ESP32_C3_Super_Mini_with_DHT11_webServer.ino)
+
+### **4. WiFi Scanner mit OLED**:
+
+  **Scanne nach WLAN-Netzen und zeige bis zu fünf Netzwerknamen mit ihrer Signalstärke in Prozent an.**
+  - Guide: [WiFi Scanner mit OLED](/docs/examples/ESP32_C3_Super_Mini_WiFi_Scan_OLED/README.md)
+  - Code: [ESP32_C3_Super_Mini_WiFi_Scan_OLED.ino](/docs/examples/ESP32_C3_Super_Mini_WiFi_Scan_OLED/ESP32_C3_Super_Mini_WiFi_Scan_OLED.ino)
 
 ---
 

--- a/docs/examples/ESP32_C3_Super_Mini_WiFi_Scan_OLED/ESP32_C3_Super_Mini_WiFi_Scan_OLED.ino
+++ b/docs/examples/ESP32_C3_Super_Mini_WiFi_Scan_OLED/ESP32_C3_Super_Mini_WiFi_Scan_OLED.ino
@@ -1,0 +1,69 @@
+#include <WiFi.h>
+#include <Wire.h>
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
+
+#define SCREEN_WIDTH 128
+#define SCREEN_HEIGHT 64
+
+#define OLED_RESET    -1
+Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
+
+void setup() {
+  Serial.begin(115200);
+  // Initialize I2C explicitly on GPIO8 (SDA) and GPIO9 (SCL)
+  Wire.begin(8, 9);
+  if(!display.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {
+    Serial.println(F("SSD1306 allocation failed"));
+    for(;;);
+  }
+
+  display.clearDisplay();
+  display.setTextSize(1);
+  display.setTextColor(SSD1306_WHITE);
+  display.setCursor(0,0);
+  display.println("WiFi Scan");
+  display.display();
+
+  WiFi.mode(WIFI_STA);
+  WiFi.disconnect();
+  delay(100);
+}
+
+void loop() {
+  display.clearDisplay();
+  display.setCursor(0,0);
+  display.println("Scanning...");
+  display.display();
+  int n = WiFi.scanNetworks();
+  display.clearDisplay();
+  display.setCursor(0,0);
+  if(n < 0) {
+    display.println("Scan failed");
+  } else if(n == 0) {
+    display.println("No networks found");
+  } else {
+    display.print(n);
+    display.println(" networks:");
+    for (int i = 0; i < n && i < 5; ++i) {
+      display.print(i + 1);
+      display.print('.');
+      display.print(' ');
+      display.print(WiFi.SSID(i));
+      display.print(' ');
+      int rssi = WiFi.RSSI(i);
+      int quality = 0;
+      if (rssi <= -100) {
+        quality = 0;
+      } else if (rssi >= -50) {
+        quality = 100;
+      } else {
+        quality = 2 * (rssi + 100);
+      }
+      display.print(quality);
+      display.println('%');
+    }
+  }
+  display.display();
+  delay(5000);
+}

--- a/docs/examples/ESP32_C3_Super_Mini_WiFi_Scan_OLED/README.md
+++ b/docs/examples/ESP32_C3_Super_Mini_WiFi_Scan_OLED/README.md
@@ -1,0 +1,35 @@
+# ESP32-C3 Super Mini WiFi Scanner with OLED
+
+Dieses Beispiel zeigt, wie man verfügbare WLAN-Netzwerke scannt und deren Namen mit Signalstärke auf einem 0,96" OLED Display ausgibt. Die Signalstärke wird als Prozentwert hinter dem Netzwerknamen angezeigt.
+
+## Schaltplan
+
+Verbinde das OLED Display über I2C mit dem ESP32-C3 Super Mini.
+Der Sketch initialisiert den I2C-Bus explizit auf folgenden Pins:
+
+- **SDA** -> GPIO8
+- **SCL** -> GPIO9
+- **VCC** -> 3.3V
+- **GND** -> GND
+
+![Schematic](images/schematic.jpg)
+
+## Bibliotheken
+
+Stelle sicher, dass folgende Bibliotheken in der Arduino IDE installiert sind:
+
+- **WiFi** (bereits in den ESP32 Boards enthalten)
+- **Adafruit SSD1306**
+- **Adafruit GFX Library**
+- **Wire** (Standardbibliothek)
+
+## Code Hochladen
+
+1. Öffne die Datei `ESP32_C3_Super_Mini_WiFi_Scan_OLED.ino` in der Arduino IDE.
+2. Wähle unter **Werkzeuge > Board** dein ESP32-C3 Board aus.
+3. Schließe das Board an und wähle den entsprechenden Port.
+4. Lade den Sketch hoch.
+
+Nach dem Upload zeigt das Display die gefundenen WLAN-Netze mit ihrer Signalstärke an.
+
+Der Sketch zeigt beim Starten kurz "Scanning..." an und listet anschließend bis zu fünf Netzwerke nummeriert auf. Hinter jedem Namen erscheint die empfangene Signalstärke in Prozent.

--- a/docs/examples/ESP32_C3_Super_Mini_WiFi_Scan_OLED/images/schematic.jpg
+++ b/docs/examples/ESP32_C3_Super_Mini_WiFi_Scan_OLED/images/schematic.jpg
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
## Summary
- link WiFi scanner example from main README

## Testing
- `cppcheck --enable=all docs/examples/ESP32_C3_Super_Mini_WiFi_Scan_OLED/ESP32_C3_Super_Mini_WiFi_Scan_OLED.ino`
- `arduino-cli compile --fqbn esp32:esp32:makergo_c3_supermini docs/examples/ESP32_C3_Super_Mini_WiFi_Scan_OLED/ESP32_C3_Super_Mini_WiFi_Scan_OLED.ino` *(fails: platform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6870208c3e74832192eadb6a6ea93c8c